### PR TITLE
Adición de protección contra desbordamiento de enteros

### DIFF
--- a/condicionales/Cargo.toml
+++ b/condicionales/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 functions = {path = "../functions"}
 
+[profile.release]
+overflow-checks = true
+
 [[bin]]
 name = "1-6"
 path = "src/1-6.rs"

--- a/crate_create.sh
+++ b/crate_create.sh
@@ -19,6 +19,9 @@ echo "edition = \"2021\"" >> $crate_name/Cargo.toml
 echo "" >> $crate_name/Cargo.toml
 echo "[dependencies]" >> $crate_name/Cargo.toml
 echo "functions = {path = \"../functions\"}" >> $crate_name/Cargo.toml
+echo "" >> $crate_name/Cargo.toml
+echo "[profile.release]" >> $crate_name/Cargo.toml
+echo "overflow-checks = true" >> $crate_name/Cargo.toml
 
 # Introduzco los nombres de los binarios que van a componer mi proyecto.
 echo "Introduzca el prefijo de los ejercicios de la guía."

--- a/secuenciales/Cargo.toml
+++ b/secuenciales/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 functions = {path = "../functions"}
 
+[profile.release]
+overflow-checks = true
+
 [[bin]]
 name = "1-5-1"
 path = "src/1-5-1.rs"

--- a/subacciones/Cargo.toml
+++ b/subacciones/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 functions = {path = "../functions"}
 
+[profile.release]
+overflow-checks = true
+
 [[bin]]
 name = "1-37-1"
 path = "src/1-37-1.rs"


### PR DESCRIPTION
Este PR sirve para agrupar los commits relacionados al ticket #2. Medidas que se deben tomar:

- [X] Adición los controles de desbordamiento de enteros del perfil "debug" al perfil "release".
- [ ] Reemplazo del tipo de dato de los enteros de i16 a i64 o u16 a u64 según sea necesario.
- [ ] Adopción de los métodos provistos por el lenguaje para lidiar con el desbordamiento de enteros en operaciones aritméticas.